### PR TITLE
FTL Mass limit increased from 300 to 1000

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -105,7 +105,7 @@ public sealed partial class CCVars
     ///     Any value equal to or less than zero will disable this check.
     /// </summary>
     public static readonly CVarDef<float> FTLMassLimit =
-        CVarDef.Create("shuttle.mass_limit", 300f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.mass_limit", 1000f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How long to knock down entities for if they aren't buckled when FTL starts and stops.


### PR DESCRIPTION
## About the PR
This PR seeks to change the Hardcodes FTL mass limit to allow microstations to FTL.

## Why / Balance
Currently the FTL limit is set to grids with masses of less then 300. This prevents shuttle stations such as Reach or Torpedo access to a vital component of shuttle gameplay - FTL.

On review of low-pop non shuttle stations, they have the following mass:
Elkridge 4704.
Packed 4606
Omega 4016


True Micro-pop station masses and large shuttles
Torpedo 725
Planned Syndicate Cruiser 667
Barratry Evac NT Raven 613
Reach 576.86
Infiltrator 204

The NT Raven sets a precedent for large shuttles being capable of FTL. Ultra-lowpop gameplay would be enriched by these shuttle-stations being able to FTL to expeditions or evade meteors with tactical FTL usage.

## Technical Details
Late-station-14/Content.Shared/CCVar/CCVars.Shuttle.cspublic static readonly CVarDef<float> FTLMassLimit =
Previously-> CVarDef.Create("shuttle.mass_limit", 300f, CVar.SERVERONLY); 
Changed to -> CVarDef.Create("shuttle.mass_limit", 1000f, CVar.SERVERONLY);


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking Changes
Because this is in an upstream file it will likely cause a merge conflict until the end of time. 

## Changelog
:cl:
- Tweak: adjusted FTL mass limit to allow micro stations (Reach, Torpedo, Syndicruiser) to FTL.
