### PR TITLE
Aetherium batch 3

### DIFF
--- a/Resources/Locale/en-US/_LateStation/reagents/experimental.ftl
+++ b/Resources/Locale/en-US/_LateStation/reagents/experimental.ftl
@@ -12,3 +12,12 @@ reagent-desc-sapphirearithrazine = A curious mix of arithrazine and aetherium; a
 
 reagent-name-azurediphenhydramine = azure diphenhydramine
 reagent-desc-azurediphenhydramine = An unexpected combination of diphenhydramine and Aetherium, resulting in a cryogenic medicine that can treat even the dead. Causes severe cold burns, and is incredibly toxic if used at higher temperatures.
+
+reagent-name-agentc = Agent C
+reagent-desc-agentc = A peculiar chemical, developed by a certain NT doctor in his youth. It seems to be eerily potent.
+
+reagent-name-imperialhyperzine = Imperial Hyperzine
+reagent-desc-imperialhyperzine = A very dangerous modification of Hyperzine. Jolts the nervous system on the user, pushing them well beyond their limits, making them appear superhuman. As a result of this, the moment it runs out, the user will be left extremely vulnerable. May cause heart attack when used. Do not use if possible.
+
+reagent-name-glowthjuice = glowth juice
+reagent-desc-glowthjuice = This mysterious chemical makes your body shine with a warm light. Best not used when going to sleep.

--- a/Resources/Locale/en-US/guidebook/chemistry/statuseffects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/statuseffects.ftl
@@ -14,3 +14,6 @@ reagent-effect-status-effect-StaminaModifier = modified stamina
 reagent-effect-status-effect-RadiationProtection = radiation protection
 reagent-effect-status-effect-Drowsiness = drowsiness
 reagent-effect-status-effect-Adrenaline = adrenaline
+
+# Latestation additions
+reagent-effect-status-effect-PointLight = glowing

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,6 +10,7 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
+    HolofanProjector: 2 #Latestation Addition
   contrabandInventory:
     CowToolboxFilled: 1
     DrinkBeerCan: 3

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -138,6 +138,7 @@
     - RadiationProtection
     - Drowsiness
     - Adrenaline
+    - PointLight # Latestation addition; Glowth Juice -chemical.
   - type: Body
     prototype: Human
     requiredLegs: 2

--- a/Resources/Prototypes/_LateStation/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/_LateStation/Catalog/Fills/Crates/fun.yml
@@ -7,14 +7,20 @@
   - type: StorageFill
     contents:
     - id: ToyPlushieAtlas
+    - id: ToyPlushieBets
+    - id: ToyPlushieDino
     - id: ToyPlushieDrafts
     - id: ToyPlushieEris
     - id: ToyPlushieGarret
     - id: ToyPlushieHides
     - id: ToyPlushieIris
+    - id: ToyPlushieJames
+    - id: ToyPlushieJuan
     - id: ToyPlushieJuni
     - id: ToyPlushieKicks
     - id: ToyPlushieLucerne
+    - id: ToyPlushieMarcus
+    - id: ToyPlushiePebbles
     - id: ToyPlushieQuiet
     - id: ToyPlushieRadios
     - id: ToyPlushieRose

--- a/Resources/Prototypes/_LateStation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_LateStation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -28,11 +28,11 @@
   - type: StaticPrice
     price: 600
   - type: Battery
-    maxCharge: 2080
-    startingCharge: 2080
+    maxCharge: 1560
+    startingCharge: 1560
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserWeak
-    fireCost: 80
+    fireCost: 60
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus

--- a/Resources/Prototypes/_LateStation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_LateStation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -8,4 +8,4 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 6
+        Heat: 8

--- a/Resources/Prototypes/_LateStation/Reagents/Experimental.yml
+++ b/Resources/Prototypes/_LateStation/Reagents/Experimental.yml
@@ -89,7 +89,7 @@
 
 #Cryo arith, nuff said
 - type: reagent
-  id : SapphireArithrazine
+  id: SapphireArithrazine
   name: reagent-name-sapphirearithrazine
   group: Experimental
   desc: reagent-desc-sapphirearithrazine
@@ -111,9 +111,30 @@
           groups:
             Brute: 2
 
+#Hmm
+- type: reagent
+  id: GlowthJuice
+  name: reagent-name-glowthjuice
+  group: Experimental
+  desc: reagent-desc-glowthjuice
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: acid
+  color: "#ffe600"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:GenericStatusEffect
+        key: PointLight
+        component: PointLight
+        type: Add
+        time: 5
+        refresh: true
+      
+
 #Cryo diphen, with a downside!
 - type: reagent
-  id : AzureDiphenhydramine
+  id: AzureDiphenhydramine
   name: reagent-name-azurediphenhydramine
   group: Experimental
   desc: reagent-desc-azurediphenhydramine
@@ -137,5 +158,128 @@
           max: 170
         damage:
           types:
-            Poison: -1
+            Poison: -2
             Cold: 3
+
+# Shh, it is a secret...!
+- type: reagent
+  id: AgentC
+  name: reagent-name-agentc
+  group: Secret
+  desc: reagent-desc-agentc
+  physicalDesc: reagent-physical-desc-cold
+  flavor: medicine
+  color: "#afafaf"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+        - !type:HealthChange
+          conditions:
+          - !type:Temperature
+            max: 180
+          damage:
+            groups:
+              Brute: -7
+              Burn: -8
+            types:
+              Poison: -4
+
+# The ultimate energy drink.
+- type: reagent
+  id: ImperialHyperzine
+  name: reagent-name-imperialhyperzine
+  group: Experimental
+  desc: reagent-desc-imperialhyperzine
+  physicalDesc: reagent-physical-desc-energizing
+  flavor: sharp
+  color: "#66023C"
+  metabolisms:
+    Narcotic:
+      metabolismRate: 0.25
+      effects:
+      - !type:MovespeedModifier
+        conditions:
+          - !type:ReagentThreshold
+            min: 3
+        walkSpeedModifier: 1.5
+        sprintSpeedModifier: 1.5
+      - !type:HealthChange
+        conditions:
+          - !type:ReagentThreshold
+            min: 30
+        damage:
+          types:
+            Asphyxiation: 10 #ODing will result in instant heart attack.
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: ChloralHydrate
+          min: 1
+        reagent: ChloralHydrate
+        amount: -10
+      - !type:AdjustReagent # Cannot be used with standard hyperzine.
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Stimulants 
+          min: 1
+        reagent: Stimulants
+        amount: -10
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 4
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 4
+        type: Remove
+      - !type:GenericStatusEffect
+        key: StaminaModifier
+        component: StaminaModifier
+        time: 4
+        type: Add
+      - !type:GenericStatusEffect
+        key: ForcedSleep
+        time: 4
+        type: Remove
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Haloperidol
+          max: 0.01
+        key: Drowsiness
+        time: 30
+        type: Remove
+    Medicine:
+      metabolismRate: 0.25
+      effects:
+        - !type:ResetNarcolepsy
+        - !type:SatiateHunger
+          factor: 1
+        - !type:SatiateThirst
+          factor: 1
+        - !type:HealthChange
+          conditions:
+          - !type:TotalDamage
+            min: 60 # only heals when you're more dead than alive
+          damage: # Will heal you like normal hyperzine, just a little better.
+            groups:
+              Burn: -2
+              Brute: -2
+    Poison:
+      metabolismRate: 0.25
+      effects:
+        - !type:HealthChange
+          conditions:
+          - !type:ReagentThreshold
+            max: 3
+          damage:
+            types:
+              Asphyxiation: 4
+        - !type:MovespeedModifier
+          conditions:
+          - !type:ReagentThreshold
+            max: 3
+          walkSpeedModifier: 0.3
+          sprintSpeedModifier: 0.3
+      

--- a/Resources/Prototypes/_LateStation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_LateStation/Recipes/Reactions/chemicals.yml
@@ -45,3 +45,27 @@
       amount: 10
   products:
     AzureDiphenhydramine: 5
+
+- type: reaction
+  id: AgentC
+  reactants:
+    Necrosol:
+      amount: 5
+    Aetherium:
+      amount: 1
+    CarpoToxin:
+      amount: 5
+  products:
+    AgentC: 5
+
+- type: reaction
+  id: GlowthJuice
+  reactants:
+    Sulfur:
+      amount: 10
+    Aetherium:
+      amount: 1
+    Carbon:
+      amount: 10
+  products:
+    GlowthJuice: 20

--- a/Resources/Prototypes/_LateStation/status_effects.yml
+++ b/Resources/Prototypes/_LateStation/status_effects.yml
@@ -1,0 +1,1 @@
+# I tried to use this but I'll come back to it later. -Late

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -72,3 +72,6 @@
 - type: statusEffect
   id: Adrenaline
   alert: Adrenaline
+
+- type: statusEffect # Latestation addition
+  id: PointLight


### PR DESCRIPTION
<!-- If you are new to the LateStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? Describe your changes here. -->
Part 3 of the Aetherium stuff; Adds Imperial Hyperzine and Glowth Juice. The new hyperzine has no recipe yet for lore reasons, and is there as a teaser. Glowth Juice on the other hand makes your character glow as if they were a light source; literally giving the point light -component for a while. 

Also includes a few minor tweaks to my previous PRs.
Finally, adds the new plushies added since last time to the cargo plushie crate order.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Imperial Hyperzine is more potent than normal hyperzine, but makes you extremely slow when it runs out.
Energy Autorifle damage bumped up from 6 to 8, and battery size reduced by 1/4, with cost-per-shot lowered by the same amount. This is to slightly boost up the recharge rate.
Cryo Diphen heals 2 poison per tick now, up from 1.

## Technical Details
<!-- Provide a summary of code changes for easier review. -->
Two extra lines added to status_effect.yml (I could not yet get it to work outside of the existing file).
One extra line to the mobs base file (base.yml) in order to allow the glowing effect to work.
The rest is all in the experimental chem things like usual.

## Media
<!-- Attach media (screenshots, videos, etc.) if the PR makes in-game changes (e.g., clothing, items, features). Small fixes or refactors are exempt. -->
![kuva](https://github.com/user-attachments/assets/964dd0ff-7266-47ef-a154-5f73f3fe240d)
Imperial Hyperzine and Glowth Juice, respectively.
![image](https://github.com/user-attachments/assets/a570024b-3447-4d72-b632-48849f896093)
Imperial Hyperzine from the guidebook. Note the lack of recipe.
![image-1](https://github.com/user-attachments/assets/f911f9d7-490b-45df-8bf9-df132c1d900e)
Glowth Juice from the guidebook.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- Not following the above may result in your PR being closed at the maintainer's discretion. -->

## Breaking Changes
<!-- List any breaking changes, such as namespace changes, public class/method/field modifications, or prototype renames. Include instructions for fixing them. -->

## Changelog
<!-- Add a changelog entry below to inform players about new features or gameplay-affecting changes.
IMPORTANT: The automated changelog bot (Weh Bot) only reads entries AFTER the ':cl:' marker in this section. 
- Use the exact format: '- type: message' (e.g., '- add: Added a new feature').
- Valid types are: 'add', 'remove', 'tweak', 'fix'.
- Do NOT use these keywords (add, remove, tweak, fix) casually elsewhere in the PR body, or the bot might misinterpret them.
-->

:cl:
- add: Two new chemicals; Imperial Hyperzine and Glowth Juice
- add: More plushies to the plushie order crate!
- tweak: Energy Autorifle battery size and firepower slightly tweaked
- tweak: Slightly adjusted Azure Diphenhydramine values, making it slightly more potent.
