### PR TITLE
Fix for the status of the criminal records computer

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -128,7 +128,9 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         {
             var status = (SecurityStatus)args.Id;
             // This should reflect SetStatus in CriminalRecordsConsoleWindow.xaml.cs
-            if (status == SecurityStatus.Wanted || status == SecurityStatus.Suspected)
+            if (status == SecurityStatus.Wanted || status == SecurityStatus.Suspected
+            // LateStation added Harmony additional statuses
+                || status == SecurityStatus.Monitor || status == SecurityStatus.Search)
                 SetStatusWithReason(status);
             else
                 OnSetSecurityStatus?.Invoke(status, null);

--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -131,9 +131,12 @@ public sealed partial class CharacterRecordViewer : FancyWindow
             if (status == SecurityStatus.Wanted || status == SecurityStatus.Suspected
             // LateStation added Harmony additional statuses
                 || status == SecurityStatus.Monitor || status == SecurityStatus.Search)
+             {
                 SetStatusWithReason(status);
-            else
-                OnSetSecurityStatus?.Invoke(status, null);
+                return;
+             }
+
+            OnSetSecurityStatus?.Invoke(status, null);
         };
 
         OnClose += () => _entryView.Close();

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
@@ -16,6 +16,10 @@ using Content.Shared.Security.Components;
 using System.Linq;
 using Content.Shared.Roles.Jobs;
 
+// CD: imports
+using Content.Server._CD.Records;
+using Content.Shared._CD.Records;
+
 namespace Content.Server.CriminalRecords.Systems;
 
 /// <summary>
@@ -36,6 +40,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         SubscribeLocalEvent<CriminalRecordsConsoleComponent, RecordModifiedEvent>(UpdateUserInterface);
         SubscribeLocalEvent<CriminalRecordsConsoleComponent, AfterGeneralRecordCreatedEvent>(UpdateUserInterface);
 
+        /* CD: We disable the wizden Criminal Records computer and reuse some of the Bui events
         Subs.BuiEvents<CriminalRecordsConsoleComponent>(CriminalRecordsConsoleKey.Key, subs =>
         {
             subs.Event<BoundUIOpenedEvent>(UpdateUserInterface);
@@ -45,6 +50,17 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
             subs.Event<CriminalRecordAddHistory>(OnAddHistory);
             subs.Event<CriminalRecordDeleteHistory>(OnDeleteHistory);
             subs.Event<CriminalRecordSetStatusFilter>(OnStatusFilterPressed);
+        }); */
+
+        // CD: also subscribe to status changes from the CD records console
+        Subs.BuiEvents<CriminalRecordsConsoleComponent>(CharacterRecordConsoleKey.Key, subs =>
+        {
+            subs.Event<SelectStationRecord>(OnKeySelected);
+            subs.Event((Entity<CriminalRecordsConsoleComponent> ent, ref CriminalRecordChangeStatus args) =>
+            {
+                OnChangeStatus(ent, ref args);
+                RaiseLocalEvent(ent, new CharacterRecordsModifiedEvent());
+            });
         });
     }
 


### PR DESCRIPTION
<!-- If you are new to the LateStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? Describe your changes here. -->

We changed the fact that security was not able to assign a status to people via the new records computer.
This had to do with the fact that the criminal records system was not subscribed to the CharacterRecords from CD.
Another oversight by yours truely. _thanks for noticeing Juan_

Also since Harmoy uses two more statuses  "Monitor" and "Search" these were not added in the CharacterRecordViewer at first but have been added so that that functionality is also there. Plus its an overall nice to have.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Why? Because this was a broken feature and had to be fixed.

## Technical Details
<!-- Provide a summary of code changes for easier review. -->

The technical details are that in CriminalRecordsConsoleSystem.CS there were a few changes. The CD records were imported from both shared and server and subscribed to so that CriminalRecords can update from the CharacterRecords UI. Plus Monitor and Search had to be added otherwise security was not able to give a reason and it would just be stuck at `Unkown variable for $reason` which is not ideal.

## Media
<!-- Attach media (screenshots, videos, etc.) if the PR makes in-game changes (e.g., clothing, items, features). Small fixes or refactors are exempt. -->

![image](https://github.com/user-attachments/assets/80ae8560-c5ae-4ede-9568-2bf7f562dafb)

![image](https://github.com/user-attachments/assets/8c076d55-a31e-4bae-96fc-42be82728ca5)

![image](https://github.com/user-attachments/assets/3119dd3f-17c9-4bc4-b988-58a2ec16a5b5)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- Not following the above may result in your PR being closed at the maintainer's discretion. -->

## Changelog
<!-- Add a changelog entry below to inform players about new features or gameplay-affecting changes.
IMPORTANT: The automated changelog bot (Weh Bot) only reads entries AFTER the ':cl:' marker in this section. 
- Use the exact format: '- type: message' (e.g., '- add: Added a new feature').
- Valid types are: 'add', 'remove', 'tweak', 'fix'.
- Do NOT use these keywords (add, remove, tweak, fix) casually elsewhere in the PR body, or the bot might misinterpret them.
-->

:cl:
- fix: Fixed the status for the Security records computer.

