### PR TITLE
Sleepemoting, and Narcolepsy forcesay.

### DIFF
--- a/Content.Server/Traits/Assorted/NarcolepsyComponent.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsyComponent.cs
@@ -1,6 +1,6 @@
 ﻿using System.Numerics;
-using Content.Shared.Dataset;
-using Robust.Shared.Prototypes;
+using Content.Shared.Dataset; // LateStation edit
+using Robust.Shared.Prototypes; // LateStation edit
 
 namespace Content.Server.Traits.Assorted;
 
@@ -25,7 +25,7 @@ public sealed partial class NarcolepsyComponent : Component
     public float NextIncidentTime;
 
     /// <summary>
-    ///     LateStation copied the sleep dataset from the sleeping component.
+    ///     LateStation, copied the sleep dataset from the sleeping component.
     ///     and it is used for the narcolepsy component.
     ///     This is the same dataset as the one used by the sleeping component.
     /// </summary>

--- a/Content.Server/Traits/Assorted/NarcolepsyComponent.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsyComponent.cs
@@ -1,4 +1,6 @@
 ﻿using System.Numerics;
+using Content.Shared.Dataset;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Traits.Assorted;
 
@@ -21,4 +23,12 @@ public sealed partial class NarcolepsyComponent : Component
     public Vector2 DurationOfIncident { get; private set; }
 
     public float NextIncidentTime;
+
+    /// <summary>
+    ///     LateStation copied the sleep dataset from the sleeping component.
+    ///     and it is used for the narcolepsy component.
+    ///     This is the same dataset as the one used by the sleeping component.
+    /// </summary>
+    [DataField]
+    public ProtoId<LocalizedDatasetPrototype> ForceSaySleepDataset = "ForceSaySleepDataset";
 }

--- a/Content.Server/Traits/Assorted/NarcolepsySystem.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsySystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage.Events;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
@@ -19,6 +20,7 @@ public sealed class NarcolepsySystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<NarcolepsyComponent, ComponentStartup>(SetupNarcolepsy);
+        SubscribeLocalEvent<NarcolepsyComponent, BeforeForceSayEvent>(OnChangeForceSay);
     }
 
     private void SetupNarcolepsy(EntityUid uid, NarcolepsyComponent component, ComponentStartup args)
@@ -59,5 +61,11 @@ public sealed class NarcolepsySystem : EntitySystem
             _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(uid, StatusEffectKey,
                 TimeSpan.FromSeconds(duration), false);
         }
+    }
+    // LateStation edit, this is the same as the one in the sleeping component.
+    // Just a repurposed copy, it might need some changes later.
+    private void OnChangeForceSay(Entity<NarcolepsyComponent> ent, ref BeforeForceSayEvent args)
+    {
+        args.Prefix = ent.Comp.ForceSaySleepDataset;
     }
 }

--- a/Content.Server/Traits/Assorted/NarcolepsySystem.cs
+++ b/Content.Server/Traits/Assorted/NarcolepsySystem.cs
@@ -1,4 +1,5 @@
-using Content.Shared.Damage.Events;
+using Content.Shared.Damage.Events; // LateStation edit
+using Content.Shared.Traits.Assorted; // LateStation edit
 using Content.Shared.Bed.Sleep;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
@@ -20,7 +21,7 @@ public sealed class NarcolepsySystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<NarcolepsyComponent, ComponentStartup>(SetupNarcolepsy);
-        SubscribeLocalEvent<NarcolepsyComponent, BeforeForceSayEvent>(OnChangeForceSay);
+        SubscribeLocalEvent<NarcolepsyComponent, BeforeForceSayEvent>(OnChangeForceSay, after: new []{typeof(PainNumbnessSystem)}); // LateStation edit
     }
 
     private void SetupNarcolepsy(EntityUid uid, NarcolepsyComponent component, ComponentStartup args)

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -319,7 +319,8 @@ public sealed partial class SleepingSystem : EntitySystem
     /// </summary>
     public void OnEmoteAttempt(Entity<SleepingComponent> ent, ref EmoteAttemptEvent args)
     {
-        args.Cancel();
+        // LateStation, Allow people to emote while sleeping
+        // args.Cancel();
     }
 
     private void OnChangeForceSay(Entity<SleepingComponent> ent, ref BeforeForceSayEvent args)


### PR DESCRIPTION
<!-- If you are new to the LateStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? Describe your changes here. -->

I changed some core files, NarcolepsySystem.cs and NarcolepsyComponent.cs so that people suffering from narcolepsy now also have the suffix "zzz..." when they drop to the floor.
And people can now use emotes when they're asleep in an effort to boost RP.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Because i am a narcolepsy enjoyer and i wanted the zzz... suffix to apply whenever i drop to the floor.
And when i do i wanna use some emotes to enhance my RP.
So with these changes i hope to add to the overall RP quality of our station.

## Technical Details
<!-- Provide a summary of code changes for easier review. -->

Added OnChangeForceSay to the Narcolepsysystem.cs so that the "zzz..." suffix gets added to people their sentences.
Commented out OnEmoteAttempt in SleepingSystem.cs so that people now may emote when they're asleep.

## Media
<!-- Attach media (screenshots, videos, etc.) if the PR makes in-game changes (e.g., clothing, items, features). Small fixes or refactors are exempt. -->


https://github.com/user-attachments/assets/fa44ba9c-eeb6-479f-837f-fd8304724f8a


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- Not following the above may result in your PR being closed at the maintainer's discretion. -->

## Breaking Changes
<!-- List any breaking changes, such as namespace changes, public class/method/field modifications, or prototype renames. Include instructions for fixing them. -->

No breaking changes observed.

## Changelog
<!-- Add a changelog entry below to inform players about new features or gameplay-affecting changes.
IMPORTANT: The automated changelog bot (Weh Bot) only reads entries AFTER the ':cl:' marker in this section. 
- Use the exact format: '- type: message' (e.g., '- add: Added a new feature').
- Valid types are: 'add', 'remove', 'tweak', 'fix'.
- Do NOT use these keywords (add, remove, tweak, fix) casually elsewhere in the PR body, or the bot might misinterpret them.
-->

:cl:
- fix: Narcoleptics now use the "zzz..." suffix on trigger
- add: You can now use emotes while you sleep.

