### PR TITLE
Give Felinids a survival box

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -21,6 +21,7 @@
     - Vulpkanin # Harmony
     - Harpy # Latestation
     - Avali # Latestation
+    - Felinid # Latestation
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox


### PR DESCRIPTION
<!-- If you are new to the LateStation repository, please read the [Contributing Guidelines](https://github.com/LateStation14/Late-station-14/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? Describe your changes here. -->
Edited survival.yml to include felinids in the oxygenbreathers

## Media
<!-- Attach media (screenshots, videos, etc.) if the PR makes in-game changes (e.g., clothing, items, features). Small fixes or refactors are exempt. -->
![image](https://github.com/user-attachments/assets/b8df94cb-5366-49f3-b0ff-7f77f794de40)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- Not following the above may result in your PR being closed at the maintainer's discretion. -->
## Changelog
<!-- Add a changelog entry below to inform players about new features or gameplay-affecting changes.
IMPORTANT: The automated changelog bot (Weh Bot) only reads entries AFTER the ':cl:' marker in this section.
- Use the exact format: '- type: message' (e.g., '- add: Added a new feature').
- Valid types are: 'add', 'remove', 'tweak', 'fix'.
- Do NOT use these keywords (add, remove, tweak, fix) casually elsewhere in the PR body, or the bot might misinterpret them.
-->

:cl:
- fix: Felinids now start with a survival box