### PR TITLE
Adds the RPD back to Atmostech Locker, and Floodlights to Engivend

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -158,6 +158,7 @@
     - id: HolofanProjector
     - id: RCD
     - id: RCDAmmo
+    - id: RPD #Harmony Change
     - id: AirGrenade
 
 - type: entityTable

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,6 +10,7 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
+    Floodlight: 2 #Harmony Change
     HolofanProjector: 2 #Latestation Addition
   contrabandInventory:
     CowToolboxFilled: 1


### PR DESCRIPTION
<!-- If you are new to the LateStation repository, please read the [Contributing Guidelines](https://github.com/LateStation14/Late-station-14/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? Describe your changes here. -->
Adds the RPD back to the Atmos Tech's locker, and Floodlights in the Engivendor
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The floodlights are a change on Harmony that is just really helpful for repairs, especially in space.  With the RPD, I'm surprised this wasn't added back sooner, it's a major help in conserving steel and quickly piping distro or whatever is needed.
## Technical Details
<!-- Provide a summary of code changes for easier review. -->
Edited engineer.yml to include the RPD in the list of items for a filled Atmos Tech Locker.  Edited engivend.yml to include 2 Floodlights in its inventory.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- Not following the above may result in your PR being closed at the maintainer's discretion. -->

## Changelog
<!-- Add a changelog entry below to inform players about new features or gameplay-affecting changes.
IMPORTANT: The automated changelog bot (Weh Bot) only reads entries AFTER the ':cl:' marker in this section.
- Use the exact format: '- type: message' (e.g., '- add: Added a new feature').
- Valid types are: 'add', 'remove', 'tweak', 'fix'.
- Do NOT use these keywords (add, remove, tweak, fix) casually elsewhere in the PR body, or the bot might misinterpret them.
-->

:cl:
- add: Added floodlights to the engivend.
- fix: Added the RPD back to atmospheric techicians' lockers.
