### PR TITLE
Fixed the PAYDAY masks baldifying people

### DIFF
--- a/Resources/Prototypes/_LateStation/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_LateStation/Entities/Clothing/Masks/masks.yml
@@ -1,6 +1,7 @@
 - type: entity
-  parent: ClothingMaskClown
+  parent: ClothingMaskBase
   id: ClothingMaskClownDallas
+  abstract: false
   name: USA clown mask
   description: Fun fact, this used to be given to patients in the medbay that haven't recieved treatment yet.
   components:
@@ -8,21 +9,43 @@
     sprite: _LateStation/Clothing/Mask/dallas.rsi
   - type: Clothing
     sprite: _LateStation/Clothing/Mask/dallas.rsi
+  - type: BreathMask
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - ClownMask
+    - HamsterWearable
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout
 
 - type: entity
-  parent: ClothingMaskClown
+  parent: ClothingMaskBase
   id: ClothingMaskClownChains
+  abstract: false
   name: purple clown mask
-  description: Contrary to popular belief, you can't use this in a machine.
+  description: Contrary to popular belief, you can't use this to secure your bike.
   components:
   - type: Sprite
     sprite: _LateStation/Clothing/Mask/chains.rsi
   - type: Clothing
     sprite: _LateStation/Clothing/Mask/chains.rsi
+  - type: BreathMask
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - ClownMask
+    - HamsterWearable
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout
 
 - type: entity
-  parent: ClothingMaskClown
+  parent: ClothingMaskBase
   id: ClothingMaskClownHoxton
+  abstract: false
   name: pink clown mask
   description: It smells like a time paradox waiting to happen.
   components:
@@ -30,10 +53,21 @@
     sprite: _LateStation/Clothing/Mask/hoxton.rsi
   - type: Clothing
     sprite: _LateStation/Clothing/Mask/hoxton.rsi
+  - type: BreathMask
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - ClownMask
+    - HamsterWearable
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout
 
 - type: entity
-  parent: ClothingMaskClown
+  parent: ClothingMaskBase
   id: ClothingMaskClownWolf
+  abstract: false
   name: bloody clown mask
   description: There's not actually blood on it. Sure looks like it, though.
   components:
@@ -41,3 +75,13 @@
     sprite: _LateStation/Clothing/Mask/wolf.rsi
   - type: Clothing
     sprite: _LateStation/Clothing/Mask/wolf.rsi
+  - type: BreathMask
+  - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - ClownMask
+    - HamsterWearable
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - Snout


### PR DESCRIPTION
## About the PR
Fixed a bug with the PAYDAY masks that occurred due to the shitty parenting of the clown masks.

## Why / Balance
Bugfix

## Technical Details
changes all the prototypes of the PAYDAY masks to avoid hair disappearance

## Media
![image](https://github.com/user-attachments/assets/e67c149c-22fb-4bf7-a133-4bbd06ee8e99)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking Changes
if you have something parented to a PAYDAY mask (you don't) the prototype will likely explode

## Changelog

:cl:
- fix: Removes the Syndicate-Brand Hair Repellant from the PAYDAY masks, meaning you won't randomly become bald.
