### PR TITLE
Bring the brigmedic syringe gun in line with the normal one

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -11,7 +11,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,0,0
+    - 0,0,2,0
     whitelist:
       tags:
       - SyringeGunAmmo


### PR DESCRIPTION
## About the PR
Gives the brigmedic syringe gun (and consequently Annabelle's) two extra syringe slots, making it equal to the medical one.

## Why / Balance
I was asked to, also it's really stupid it doesn't work the same.

## Technical Details
Changed literally one character in the brigmed's syringe gun

## Media
![image](https://github.com/user-attachments/assets/cc49a9be-c6df-41c4-8637-3a90118c9c55)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking Changes
No.

## Changelog
:cl:
- tweak: The brigmedic syringe gun now holds three syringes, like its counterpart.
