### PR TITLE
Fixes the personal item for Mary because i'm a fucking idiot

### DIFF
--- a/Resources/Prototypes/_LateStation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_LateStation/Loadouts/loadout_groups.yml
@@ -19,3 +19,4 @@
   - PersonalItemIrisGlasses
   - PersonalItemBringsHoodie
   - PersonalItemAustinMothCloak
+  - PersonalItemMaryCollar


### PR DESCRIPTION
## About the PR
Fixes the personal item for Mary Whitewitch not showing up in loadouts, because I'm a moron and forgot to add a loadout entry

## Why / Balance
Bugfix

## Technical Details
Adds a single line to the personal item loadoutgroups

## Media
no.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking Changes
no

## Changelog

:cl:
- fix: Made the personal item for Mary Whitewitch actually Work™
