### PR TITLE
Loadout item playtime restrictions removed, new soft brick added to trinkets, 5 trinket slots

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -55,9 +55,6 @@
   id: QuartermasterMantle
   equipment: 
     neck: ClothingNeckMantleQM
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterQM
 
 - type: startingGear
   id: QuartermasterMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -49,9 +49,6 @@
 # Misc
 - type: loadout
   id: JanitorGoldenPlunger
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorJanitorial
   storage:
     back:
     - GoldenPlunger

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -21,9 +21,6 @@
 # Face
 - type: loadout
   id: PassengerFace
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
   equipment:
     mask: ClothingMaskGas
 
@@ -42,27 +39,18 @@
 # Rainbow
 - type: loadout
   id: RainbowJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
   equipment:
     jumpsuit: ClothingUniformColorRainbow
 
 # Rainbow Jumpskirt
 - type: loadout
   id: RainbowJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorRainbow
 
 # Ancient
 - type: loadout
   id: AncientJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
   equipment:
     jumpsuit: ClothingUniformJumpsuitAncient
 
@@ -71,9 +59,6 @@
   id: Mantle
   equipment:
     neck: ClothingNeckMantle
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterGrey
 
 - type: startingGear
   id: Mantle
@@ -99,9 +84,6 @@
 # Gloves
 - type: loadout
   id: PassengerGloves
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
   equipment:
     gloves: ClothingHandsGlovesFingerlessInsulated
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -55,9 +55,6 @@
   id: CaptainMantle
   equipment:
     neck: ClothingNeckMantleCap
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCap
 
 - type: startingGear
   id: CaptainMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -45,9 +45,6 @@
   id: HoPMantle
   equipment:
     neck: ClothingNeckMantleHOP
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterHoP
 
 - type: startingGear
   id: HoPMantle
@@ -57,9 +54,6 @@
 # Back
 - type: loadout
   id: HoPBackpackIan
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: ProfessionalHoP
   equipment:
     back: ClothingBackpackIan
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -49,9 +49,6 @@
   id: ChiefEngineerMantle
   equipment:
     neck: ClothingNeckMantleCE
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCE
 
 - type: startingGear
   id: ChiefEngineerMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -42,9 +42,6 @@
 - type: loadout
   id: SeniorEngineerBeret
   startingGear: EngineeringBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
 
 # Jumpsuit
 - type: loadout
@@ -64,17 +61,11 @@
 
 - type: loadout
   id: SeniorEngineerJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorEngineer
 
 - type: loadout
   id: SeniorEngineerJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorEngineer
 
@@ -124,8 +115,5 @@
 
 - type: loadout
   id: SeniorEngineerPDA
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
   equipment:
     id: SeniorEngineerPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -50,9 +50,6 @@
   id: ChiefMedicalOfficerMantle
   equipment:
     neck: ClothingNeckMantleCMO
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCMO
 
 - type: startingGear
   id: ChiefMedicalOfficerMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -33,17 +33,11 @@
 
 - type: loadout
   id: SeniorPhysicianBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
 - type: loadout
   id: MedicalHeadMirror
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MedicalHeadMirrorTimer
   equipment:
     head: ClothingHeadMirror
 
@@ -85,17 +79,11 @@
 
 - type: loadout
   id: SeniorPhysicianJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
 
 - type: loadout
   id: SeniorPhysicianJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorPhysician
 
@@ -138,9 +126,6 @@
 
 - type: loadout
   id: SeniorPhysicianLabCoat
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician
 
@@ -158,9 +143,6 @@
 
 - type: loadout
   id: SeniorPhysicianPDA
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     id: SeniorPhysicianPDA
 

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -18,9 +18,6 @@
   id: ResearchDirectorMantle
   equipment:
     neck: ClothingNeckMantleRD
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterRD
 
 - type: startingGear
   id: ResearchDirectorMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -17,9 +17,6 @@
 - type: loadout
   id: ScientificBeret
   startingGear: ScientificBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
 
 - type: loadout
   id: RoboticistCap
@@ -61,17 +58,11 @@
 
 - type: loadout
   id: SeniorResearcherJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorResearcher
 
 - type: loadout
   id: SeniorResearcherJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorResearcher
 
@@ -119,9 +110,6 @@
 
 - type: loadout
   id: SeniorResearcherLabCoat
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorResearcher
 
@@ -150,8 +138,5 @@
 
 - type: loadout
   id: SeniorResearcherPDA
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
   equipment:
     id: SeniorResearcherPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -66,9 +66,6 @@
   id: HeadofSecurityMantle
   equipment:
     neck: ClothingNeckMantleHOS
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterHoS
 
 - type: startingGear
   id: HeadofSecurityMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -72,17 +72,11 @@
 
 - type: loadout
   id: SeniorOfficerJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorOfficer
 
 - type: loadout
   id: SeniorOfficerJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorOfficer
 
@@ -153,18 +147,12 @@
 
 - type: loadout
   id: SeniorOfficerPDA
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
   equipment:
     id: SeniorOfficerPDA
 
 # Misc
 - type: loadout
   id: SecStar
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SecurityStarWorthy
   storage:
     back:
     - Dinkystar

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -28,17 +28,11 @@
 # Jamjar
 - type: loadout
   id: GlassesJamjar
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: JamjarTimer
   equipment:
     eyes: ClothingEyesGlassesJamjar
 
 # Jensen
 - type: loadout
   id: GlassesJensen
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: JensenTimer
   equipment:
     eyes: ClothingEyesGlassesJensen

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -88,9 +88,6 @@
 
 - type: loadout
   id: CigarCase
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Command
   storage:
     back:
     - CigarCase
@@ -98,9 +95,6 @@
 
 - type: loadout
   id: CigarGold
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Command
   storage:
     back:
     - CigarGold
@@ -251,12 +245,6 @@
 
 - type: loadout
   id: OffsetCaneClown
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobClown
-      time: 3600 # 1hr
   storage:
     back:
     - OffsetCaneClown
@@ -264,12 +252,6 @@
 
 - type: loadout
   id: OffsetCaneMime
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobMime
-      time: 3600 # 1hr
   storage:
     back:
     - OffsetCaneMime
@@ -277,12 +259,6 @@
 
 - type: loadout
   id: OffsetCaneNT
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Command
-      time: 18000 # 5hr
   storage:
     back:
     - OffsetCaneNT
@@ -290,12 +266,6 @@
 
 - type: loadout
   id: Cane
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobLibrarian
-      time: 3600 # 1hr same as Jamjar.
   storage:
     back:
     - Cane
@@ -304,11 +274,6 @@
 # Towels
 - type: loadout
   id: TowelColorWhite
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:OverallPlaytimeRequirement
-      time: 36000 # 10hr
   storage:
     back:
     - TowelColorWhite
@@ -316,11 +281,6 @@
 
 - type: loadout
   id: TowelColorSilver
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:OverallPlaytimeRequirement
-      time: 1800000 # 500hr
   storage:
     back:
     - TowelColorSilver
@@ -328,11 +288,6 @@
 
 - type: loadout
   id: TowelColorGold
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:OverallPlaytimeRequirement
-      time: 3600000 # 1000hr
   storage:
     back:
     - TowelColorGold
@@ -340,12 +295,6 @@
 
 - type: loadout
   id: TowelColorLightBrown
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorLightBrown
@@ -353,12 +302,6 @@
 
 - type: loadout
   id: TowelColorGreen
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Civilian
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorGreen
@@ -366,12 +309,6 @@
 
 - type: loadout
   id: TowelColorDarkBlue
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Command
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorDarkBlue
@@ -379,12 +316,6 @@
 
 - type: loadout
   id: TowelColorOrange
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorOrange
@@ -392,12 +323,6 @@
 
 - type: loadout
   id: TowelColorLightBlue
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Medical
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorLightBlue
@@ -405,12 +330,6 @@
 
 - type: loadout
   id: TowelColorPurple
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Science
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorPurple
@@ -418,12 +337,6 @@
 
 - type: loadout
   id: TowelColorRed
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Security
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorRed
@@ -431,12 +344,6 @@
 
 - type: loadout
   id: TowelColorGray
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobPassenger
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorGray
@@ -444,12 +351,6 @@
 
 - type: loadout
   id: TowelColorBlack
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobChaplain
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorBlack
@@ -457,12 +358,6 @@
 
 - type: loadout
   id: TowelColorDarkGreen
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobLibrarian
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorDarkGreen
@@ -470,12 +365,6 @@
 
 - type: loadout
   id: TowelColorMaroon
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobLawyer
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorMaroon
@@ -483,12 +372,6 @@
 
 - type: loadout
   id: TowelColorYellow
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobClown
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorYellow
@@ -496,12 +379,6 @@
 
 - type: loadout
   id: TowelColorMime
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobMime
-      time: 360000 # 100hr
   storage:
     back:
     - TowelColorMime

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -3,7 +3,7 @@
   id: Trinkets
   name: loadout-group-trinkets
   minLimit: 0
-  maxLimit: 3
+  maxLimit: 5
   loadouts:
   - FlowerWreath
   - Hairflower
@@ -69,6 +69,7 @@
   - TowelStripedOrange # Harmony
   - Cane # Harmony
   - TapeRecorder # DeltaV / Harmony
+  - ThrowingBrickSoft
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Cargo/cargo_technician.yml
@@ -26,9 +26,6 @@
 
 - type: loadout
   id: SeniorTechnicianBeretHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorTechnician
   equipment:
     head: ClothingHeadHatBeretSeniorTechnicianHarmony
 
@@ -45,9 +42,6 @@
 
 - type: loadout
   id: SeniorTechnicianJumpsuitHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorTechnician
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorTechnicianHarmony
 
@@ -64,8 +58,5 @@
 
 - type: loadout
   id: SeniorTechnicianJumpskirtHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorTechnician
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorTechnicianHarmony

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Civilian/librarian.yml
@@ -10,17 +10,11 @@
 # Coat
 - type: loadout
   id: CuratorCoatHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorLibrarian
   equipment:
     outerClothing: ClothingOuterCuratorCoat
 
 # Mantle
 - type: loadout
   id: CuratorMantleHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorLibrarian
   equipment:
     neck: ClothingNeckMantleCurator

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,8 +1,5 @@
 - type: loadout
   id: WorkadaySuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
   equipment:
     jumpsuit: ClothingUniformJumpsuitWorkaday
 

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Security/security_officer.yml
@@ -11,9 +11,6 @@
 
 - type: loadout
   id: SeniorOfficerBeretHarmony
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
   equipment:
     head: ClothingHeadHatBeretSecuritySeniorOfficerHarmony
 

--- a/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
@@ -74,12 +74,6 @@
 # Towels
 - type: loadout
   id: TowelStripedOrange
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobPermaPrisoner
-      time: 360000 # 100hr
   storage:
     back:
     - TowelStripedOrange

--- a/Resources/Prototypes/_LateStation/Objects/Weapons/Throwable/brick.yml
+++ b/Resources/Prototypes/_LateStation/Objects/Weapons/Throwable/brick.yml
@@ -25,3 +25,37 @@
         Blunt: 10
   - type: StaminaDamageOnCollide
     damage: 10
+
+- type: entity
+  parent: BaseItem
+  id: ThrowingBrickSoft
+  name: brick
+  description: It's a crumbling brick. It'll probably last, but won't really do much.
+  components:
+  - type: Sprite
+    sprite: _LateStation/Objects/Weapons/Throwable/brick.rsi
+    state: icon
+  - type: Appearance
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.2
+        density: 5
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
+  - type: StaminaDamageOnCollide
+    damage: 15
+
+- type: loadout
+  id: ThrowingBrickSoft
+  storage:
+    back:
+    - ThrowingBrickSoft


### PR DESCRIPTION
## About the PR
Removed all playtime restrictions from loadout items of all kinds, including towels, cigars, mantles, etc.
Added a new loadout brick that deals less damage than the normal one.
Raised max trinket count from 3 to 5 to account for the amount of trinkets + lighters commonly being paired with cigarettes / cigars.

## Why / Balance
Trinkets don't do much, so why not have more per person?
Also throwing bricks at people is REALLY FUNNY.
Playtime removal commonly requested.

## Technical Details
Removed the playtime effect from every loadout item. Regh.
Added a new brick item and a way to get it through loadouts.
Trinket max count raised to five.

## Media (if applicable)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4c5a745-8017-4a6d-85e0-ef68d6037d76" />


## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [x] I have tested all added content and code changes.
- [x] I have added media to this PR, or it does not require an in-game showcase.
- [x] I have added the changes i've made to the respective _LateStation folder or commented it with LateStation
- [x] I understand that by submitting this PR, my code contributions are licensed under the MIT and AGPL-3.0-or-later license used by LateStation.


## Breaking Changes
99% chance of everything being fine, just check back every update to see if any new items with restrictions were added

## Changelog

:cl:
- add: Added a crumbling brick to the trinket loadout list. Throw them at hapless girlkissers.
- tweak: Removed ALL playtime requirements from loadout items.
- tweak: You can now bring up to five trinkets. Rejoice, smokers!
