### PR TITLE
Chaplains have the Communist Manifesto holy book, some items made more common (CURRENTLY BROKEN)

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -34,12 +34,14 @@
   storage:
     back:
     - PlushieLizard
+- groupBy: "plushies" # Late
 
 - type: loadout
   id: PlushieSpaceLizard
   storage:
     back:
     - PlushieSpaceLizard
+- groupBy: "plushies" # Late
 
 - type: loadout
   id: ThreeCandles

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -8,10 +8,31 @@
   - FlowerWreath
   - Hairflower
   - Headphones
+  - Whistle # Late
   - PlushieLizard
   - PlushieSpaceLizard
   - PlushieVox # Harmony
+  - PlushieBee # Late
+  - PlushieArachnid # Late
+  - PlushieNukie # Late
+  - PlushieDiona # Late
+  - PlushieSharkBlue # Late
+  - PlushieSharkPink # Late
+  - PlushieSharkGrey # Late
+  - PlushieCarp # Late
+  - PlushieMagicarp # Late
+  - PlushieHolocarp # Late
+  - PlushieSlime # Late
+  - PlushieSnake # Late
+  - ToyMouse # Late
+  - PlushieAtmosian # Late
+  - PlushieXeno # Late
+  - PlushiePenguin # Late
+  - PlushieHuman # Late
+  - PlushieMoth # Late
+  - PersonalAI # Late
   - ThreeCandles
+  - Wristwatch # Late
   - Lighter
   - CigPackGreen
   - CigPackRed
@@ -19,6 +40,10 @@
   - CigPackBlack
   - CigarCase
   - CigarGold
+  - FlippoLighter # Late
+  - DiscountDanLighter # Late
+  - NanotrasenFlippo # Late
+  - SmokingPipe # Late
   - ClothingNeckLGBTPin
   - ClothingNeckAllyPin
   - ClothingNeckAromanticPin
@@ -63,7 +88,11 @@
   - TowelStripedOrange # Harmony
   - Cane # Harmony
   - TapeRecorder # DeltaV / Harmony
-  - ThrowingBrickSoft
+  - ThrowingBrickSoft # Late
+  - BarberScissors # Late
+  - HairBrush # Late
+  - NTHandyFlag # Late
+  - LGBTQHandyFlag # Late
 
 - type: loadoutGroup
   id: Glasses
@@ -401,6 +430,7 @@
   - BibleNanoTrasen
   - BibleSatanic
   - BibleTanakh
+  - BibleCommunistManifesto # Late
 
 - type: loadoutGroup
   id: JanitorHead

--- a/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
@@ -70,6 +70,7 @@
   storage:
     back:
     - PlushieVox
+- groupBy: "plushies" # Late
 
 # Towels
 - type: loadout

--- a/Resources/Prototypes/_LateStation/Loadouts/Jobs/Civillian/chaplain.yml
+++ b/Resources/Prototypes/_LateStation/Loadouts/Jobs/Civillian/chaplain.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: BibleCommunistManifesto
+  storage:
+    back:
+    - BibleCommunistManifesto

--- a/Resources/Prototypes/_LateStation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_LateStation/Loadouts/Miscellaneous/trinkets.yml
@@ -189,3 +189,9 @@
   storage:
     back:
       - PersonalAI
+
+- type: loadout
+  id: Whistle
+  storage:
+    back:
+      - Whistle

--- a/Resources/Prototypes/_LateStation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_LateStation/Loadouts/Miscellaneous/trinkets.yml
@@ -1,0 +1,191 @@
+- type: loadout
+  id: BarberScissors
+  storage:
+    back:
+    - BarberScissors
+
+- type: loadout
+  id: HairBrush
+  storage:
+    back:
+    - HairBrush
+
+- type: loadout
+  id: NTHandyFlag
+  storage:
+    back:
+    - NTHandyFlag
+- groupBy: "handflag"
+
+- type: loadout
+  id: LGBTQHandyFlag
+  storage:
+    back:
+    - LGBTQHandyFlag
+- groupBy: "handflag"
+
+- type: loadout
+  id: FlippoLighter
+  storage:
+    back:
+    - FlippoLighter
+- groupBy: "smokeables"
+
+- type: loadout
+  id: DiscountDanLighter
+  storage:
+    back:
+      - DiscountDanLighter
+- groupBy: "smokeables"
+
+- type: loadout
+  id: NanotrasenFlippo
+  storage:
+    back:
+      - NanotrasenFlippo
+- groupBy: "smokeables"
+
+- type: loadout
+  id: SmokingPipe
+  storage:
+    back:
+      - SmokingPipe
+- groupBy: "smokeables"
+
+- type: loadout
+  id: Wristwatch
+  storage:
+    back:
+      - Wristwatch
+
+- type: loadout
+  id: PlushieBee
+  storage:
+    back:
+      - PlushieBee
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieArachnid
+  storage:
+    back:
+      - PlushieArachnid
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieNukie
+  storage:
+    back:
+      - PlushieNukie
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieDiona
+  storage:
+    back:
+      - PlushieDiona
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieSharkBlue
+  storage:
+    back:
+      - PlushieSharkBlue
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieSharkPink
+  storage:
+    back:
+      - PlushieSharkPink
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieSharkGrey
+  storage:
+    back:
+      - PlushieSharkGrey
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieCarp
+  storage:
+    back:
+      - PlushieCarp
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieMagicarp
+  storage:
+    back:
+      - PlushieMagicarp
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieHolocarp
+  storage:
+    back:
+      - PlushieHolocarp
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieSlime
+  storage:
+    back:
+      - PlushieSlime
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieSnake
+  storage:
+    back:
+      - PlushieSnake
+- groupBy: "plushies"
+
+- type: loadout
+  id: ToyMouse
+  storage:
+    back:
+      - ToyMouse
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieAtmosian
+  storage:
+    back:
+      - PlushieAtmosian
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieXeno
+  storage:
+    back:
+      - PlushieXeno
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushiePenguin
+  storage:
+    back:
+      - PlushiePenguin
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieHuman
+  storage:
+    back:
+      - PlushieHuman
+- groupBy: "plushies"
+
+- type: loadout
+  id: PlushieMoth
+  storage:
+    back:
+      - PlushieMoth
+- groupBy: "plushies"
+
+- type: loadout
+  id: PersonalAI
+  storage:
+    back:
+      - PersonalAI


### PR DESCRIPTION
## About the PR
The chaplain can now select the Communist Manifesto in their loadout, since it functions as a holy book already.
Barber scissors, some lighters, the hairbrush, and almost every plushie has been added to the trinkets list.

## Why / Balance
Almost all of these items barely existed in the game, except for the plushies. For example, the Communist Manifesto was literally not used anywhere. The hairbrush didn't either.

## Technical Details
Creates some loadout-related files. Edits upstream loadout files for grouping and loadout addition purposes.

## Media (if applicable)
Crash occurs when opening loadout menu. Cannot get media until fixed.

## Requirements
- [ ] I have tested all added content and code changes.
- [ ] I have added media to this PR, or it does not require an in-game showcase.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by LateStation
- [X] If this PR ports or modifies AGPL code/assets, I have clearly marked it with an SPDX license header.


## Breaking Changes
Edits to Harmony trinket file. Trinket item list from Wizard's Den is edited as well.

## Changelog
:cl:
- add: Chaplains can now take the Communist Manifesto in their loadout.
- add: A lot of new trinket items have been added to loadouts.
